### PR TITLE
Fix rails proxy for 201 response with no body

### DIFF
--- a/proxies/rails/proxy_controller.rb
+++ b/proxies/rails/proxy_controller.rb
@@ -25,7 +25,7 @@ class ProxyController < ApplicationController
 
     res = https.request(req)
 
-    render :status => res.code, :json => res.body
+    render :status => res.code, :json => res.body.present? || {}
   rescue => e
     render :status => :internal_server_error, :json => {"error" => "failed #{e}"}
   end

--- a/proxies/rails/proxy_controller.rb
+++ b/proxies/rails/proxy_controller.rb
@@ -25,7 +25,7 @@ class ProxyController < ApplicationController
 
     res = https.request(req)
 
-    render :status => res.code, :json => res.body.present? || {}
+    render :status => res.code, :json => res.body.presence || {}
   rescue => e
     render :status => :internal_server_error, :json => {"error" => "failed #{e}"}
   end


### PR DESCRIPTION
The current Help Scout API returns a 201 status with no body on conversation create. When sending an empty string as JSON jQuery will never call the callback promise. This fix sends an empty hash if there is no content in the Help Scout API response.